### PR TITLE
Bump renv version

### DIFF
--- a/scripts/restore_renv.sh
+++ b/scripts/restore_renv.sh
@@ -18,7 +18,7 @@ RENV_PATHS_PREFIX_AUTO=FALSE
 if [ -f "/workspace/renv.lock" ]; then {
 	echo "Create $RENV_PATHS_CACHE and $RENV_PATHS_LIBRARY directories"
 	mkdir -p $RENV_PATHS_CACHE $RENV_PATHS_LIBRARY $TMP_LIB
-	RENV_VERSION="1.0.0"
+	RENV_VERSION="1.0.3"
 	# Install remote
 	R -e "
     install.packages(


### PR DESCRIPTION
renv 1.0.0 has few bugs when resolving dependencies, so it's impacting `restore` and `install`. 

`1.0.3` fixing known issues.