### PR TITLE
Add namespace to install.package call.

### DIFF
--- a/scripts/restore_renv.sh
+++ b/scripts/restore_renv.sh
@@ -21,7 +21,7 @@ if [ -f "/workspace/renv.lock" ]; then {
 	mkdir -p $RENV_PATHS_CACHE $RENV_PATHS_LIBRARY $TMP_LIB
 	# Install remote
 	R -e "
-    install.packages(
+    utils::install.packages(
         'remotes',
         lib = '$TMP_LIB',
         repos = 'https://cloud.r-project.org'


### PR DESCRIPTION
By default, install.package is overwriten by renv. To be sure that we install remotes using default install.package we need to add the utils namespace to it. 

For example, renv is not using lib param.